### PR TITLE
n-gram generators with stop words support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.Rproj.user
+.Rhistory
+.RData
+src/*.o
+src/*.so
+src/*.dll

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -5,6 +5,14 @@ shingle_ngrams <- function(words, n) {
     .Call('tokenizers_shingle_ngrams', PACKAGE = 'tokenizers', words, n)
 }
 
+generate_ngrams <- function(terms, ngram_min, ngram_max, stopwords = character(), ngram_delim = " ") {
+    .Call('tokenizers_generate_ngrams', PACKAGE = 'tokenizers', terms, ngram_min, ngram_max, stopwords, ngram_delim)
+}
+
+generate_ngrams_batch <- function(documents_list, ngram_min, ngram_max, stopwords = character(), ngram_delim = " ") {
+    .Call('tokenizers_generate_ngrams_batch', PACKAGE = 'tokenizers', documents_list, ngram_min, ngram_max, stopwords, ngram_delim)
+}
+
 skip_ngrams <- function(words, n, k) {
     .Call('tokenizers_skip_ngrams', PACKAGE = 'tokenizers', words, n, k)
 }

--- a/R/basic-tokenizers.R
+++ b/R/basic-tokenizers.R
@@ -65,7 +65,7 @@ tokenize_chars <- function(x, lowercase = TRUE, strip_non_alphanum = TRUE,
   if (strip_non_alphanum)
     x <- stri_replace_all_charclass(x, "[[:punct:][:whitespace:]]", "")
   out <- stri_split_boundaries(x, type = "character")
-  if (simplify & length(out) == 1) out[[1]] else out
+  simplify_list(out, simplify)
 }
 
 #' @export
@@ -74,7 +74,7 @@ tokenize_words <- function(x, lowercase = TRUE, simplify = FALSE) {
   if (is.list(x) & length(x) == 1) x <- x[[1]]
   if (lowercase) x <- stri_trans_tolower(x)
   out <- stri_split_boundaries(x, type = "word", skip_word_none = TRUE)
-  if (simplify & length(out) == 1) out[[1]] else out
+  simplify_list(out, simplify)
 }
 
 #' @export
@@ -89,7 +89,7 @@ tokenize_sentences <- function(x, lowercase = FALSE, strip_punctuation = FALSE,
     out <- lapply(out, stri_trans_tolower)
   if (strip_punctuation)
     out <- lapply(out, stri_replace_all_charclass, "[[:punct:]]", "")
-  if (simplify & length(out) == 1) out[[1]] else out
+  simplify_list(out, simplify)
 }
 
 #' @export
@@ -97,7 +97,7 @@ tokenize_sentences <- function(x, lowercase = FALSE, strip_punctuation = FALSE,
 tokenize_lines <- function(x, simplify = FALSE) {
   if (is.list(x) & length(x) == 1) x <- x[[1]]
   out <- stri_split_lines(x, omit_empty = TRUE)
-  if (simplify & length(out) == 1) out[[1]] else out
+  simplify_list(out, simplify)
 }
 
 #' @export
@@ -105,5 +105,5 @@ tokenize_lines <- function(x, simplify = FALSE) {
 tokenize_paragraphs <- function(x, paragraph_break = "\n\n", simplify = FALSE) {
   out <- stri_split_fixed(x, pattern = paragraph_break, omit_empty = TRUE)
   out <- lapply(out, stri_replace_all_charclass, "[[:whitespace:]]", " ")
-  if (simplify & length(out) == 1) out[[1]] else out
+  simplify_list(out, simplify)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,0 +1,4 @@
+simplify_list <- function(x, simplify) {
+  stopifnot(is.logical(simplify))
+  if (simplify & length(x) == 1) x[[1]] else x
+}

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,0 +1,1 @@
+CXX_STD = CXX11

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,0 +1,1 @@
+CXX_STD = CXX11

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -17,6 +17,36 @@ BEGIN_RCPP
     return __result;
 END_RCPP
 }
+// generate_ngrams
+CharacterVector generate_ngrams(const CharacterVector terms, const uint32_t ngram_min, const uint32_t ngram_max, const CharacterVector stopwords, const String ngram_delim);
+RcppExport SEXP tokenizers_generate_ngrams(SEXP termsSEXP, SEXP ngram_minSEXP, SEXP ngram_maxSEXP, SEXP stopwordsSEXP, SEXP ngram_delimSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject __result;
+    Rcpp::RNGScope __rngScope;
+    Rcpp::traits::input_parameter< const CharacterVector >::type terms(termsSEXP);
+    Rcpp::traits::input_parameter< const uint32_t >::type ngram_min(ngram_minSEXP);
+    Rcpp::traits::input_parameter< const uint32_t >::type ngram_max(ngram_maxSEXP);
+    Rcpp::traits::input_parameter< const CharacterVector >::type stopwords(stopwordsSEXP);
+    Rcpp::traits::input_parameter< const String >::type ngram_delim(ngram_delimSEXP);
+    __result = Rcpp::wrap(generate_ngrams(terms, ngram_min, ngram_max, stopwords, ngram_delim));
+    return __result;
+END_RCPP
+}
+// generate_ngrams_batch
+ListOf<CharacterVector> generate_ngrams_batch(const ListOf<const CharacterVector> documents_list, const uint32_t ngram_min, const uint32_t ngram_max, const CharacterVector stopwords, const String ngram_delim);
+RcppExport SEXP tokenizers_generate_ngrams_batch(SEXP documents_listSEXP, SEXP ngram_minSEXP, SEXP ngram_maxSEXP, SEXP stopwordsSEXP, SEXP ngram_delimSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject __result;
+    Rcpp::RNGScope __rngScope;
+    Rcpp::traits::input_parameter< const ListOf<const CharacterVector> >::type documents_list(documents_listSEXP);
+    Rcpp::traits::input_parameter< const uint32_t >::type ngram_min(ngram_minSEXP);
+    Rcpp::traits::input_parameter< const uint32_t >::type ngram_max(ngram_maxSEXP);
+    Rcpp::traits::input_parameter< const CharacterVector >::type stopwords(stopwordsSEXP);
+    Rcpp::traits::input_parameter< const String >::type ngram_delim(ngram_delimSEXP);
+    __result = Rcpp::wrap(generate_ngrams_batch(documents_list, ngram_min, ngram_max, stopwords, ngram_delim));
+    return __result;
+END_RCPP
+}
 // skip_ngrams
 CharacterVector skip_ngrams(CharacterVector words, int n, int k);
 RcppExport SEXP tokenizers_skip_ngrams(SEXP wordsSEXP, SEXP nSEXP, SEXP kSEXP) {

--- a/src/shingle_ngrams.cpp
+++ b/src/shingle_ngrams.cpp
@@ -1,4 +1,5 @@
 #include <Rcpp.h>
+using namespace std;
 using namespace Rcpp;
 
 // Create shingled n-grams
@@ -18,4 +19,113 @@ CharacterVector shingle_ngrams(CharacterVector words, int n) {
     ngrams[i] = ngram;
   }
   return ngrams;
+}
+
+// calculates size of the ngram vector
+inline  size_t get_ngram_seq_len(uint32_t input_len, uint32_t ngram_min, uint32_t ngram_max) {
+
+  uint32_t out_ngram_len_adjust = 0;
+  for (size_t i = ngram_min - 1; i < ngram_max; i++)
+    out_ngram_len_adjust += i;
+
+  if(input_len < ngram_min)
+    return 0;
+  else
+    return input_len * (ngram_max - ngram_min + 1) - out_ngram_len_adjust;
+}
+
+CharacterVector generate_ngrams_internal(const CharacterVector terms_raw,
+                                const uint32_t ngram_min,
+                                const uint32_t ngram_max,
+                                RCPP_UNORDERED_SET<string> &stopwords,
+                                // pass buffer by reference to avoid memory allocation
+                                // on each iteration
+                                vector<string> &terms_filtered_buffer,
+                                const string ngram_delim) {
+  // clear buffer from previous iteration result
+  terms_filtered_buffer.clear();
+  string term;
+  // filter out stopwords
+  for (auto it: terms_raw) {
+    term  = as<string>(it);
+    if(stopwords.find(term) == stopwords.end())
+      terms_filtered_buffer.push_back(term);
+  }
+
+  uint32_t len = terms_filtered_buffer.size();
+  size_t ngram_out_len = get_ngram_seq_len(len, ngram_min, ngram_max);
+  CharacterVector result(ngram_out_len);
+
+  string k_gram;
+  size_t k, i = 0, j_max_observed;
+  // iterates through input vector by window of size = n_max and build n-grams
+  // for terms ["a", "b", "c", "d"] and n_min = 1, n_max = 2
+  // will build 1:3-grams in following order
+  //"a"     "a_b"   "a_b_c" "b"     "b_c"   "b_c_d" "c"     "c_d"   "d"
+  for(size_t j = 0; j < len; j ++ ) {
+    k = 1;
+    j_max_observed = j;
+    while (k <= ngram_max && j_max_observed < len) {
+
+      if( k == 1) {
+        k_gram = terms_filtered_buffer[j_max_observed];
+      } else
+        k_gram = k_gram + ngram_delim + terms_filtered_buffer[j_max_observed];
+
+      if(k >= ngram_min) {
+        result[i] = k_gram;
+        i++;
+      }
+      j_max_observed = j + k;
+      k = k + 1;
+    }
+  }
+  return result;
+}
+
+// [[Rcpp::export]]
+CharacterVector generate_ngrams(const CharacterVector terms,
+                                const uint32_t ngram_min,
+                                const uint32_t ngram_max,
+                                const CharacterVector stopwords = CharacterVector(),
+                                const String ngram_delim = " ") {
+
+  const string std_string_delim = ngram_delim.get_cstring();
+  vector<string> terms_filtered_buffer;
+  RCPP_UNORDERED_SET<string> stopwords_set;
+
+  for(auto it:stopwords)
+    stopwords_set.insert(as<string>(it));
+
+  return generate_ngrams_internal(terms, ngram_min, ngram_max, stopwords_set,
+                                  terms_filtered_buffer, std_string_delim);
+}
+
+// [[Rcpp::export]]
+ListOf<CharacterVector> generate_ngrams_batch(const ListOf<const CharacterVector> documents_list,
+                                              const uint32_t ngram_min,
+                                              const uint32_t ngram_max,
+                                              const CharacterVector stopwords = CharacterVector(),
+                                              const String ngram_delim = " ") {
+
+  vector<string> terms_filtered_buffer;
+  const string std_string_delim = ngram_delim.get_cstring();
+  size_t n_docs = documents_list.size();
+  List result(n_docs);
+  CharacterVector terms;
+
+  RCPP_UNORDERED_SET<string> stopwords_set;
+  for(auto it:stopwords)
+    stopwords_set.insert(as<string>(it));
+
+  size_t current_doc_ngram_len = 0;
+  for (size_t i_document = 0; i_document < n_docs; i_document++) {
+    terms = documents_list[i_document];
+    result[i_document] = generate_ngrams_internal(documents_list[i_document],
+                                                  ngram_min, ngram_max,
+                                                  stopwords_set,
+                                                  terms_filtered_buffer,
+                                                  std_string_delim);
+  }
+  return result;
 }


### PR DESCRIPTION
Here are two n-gram generators. I didn't expose public functions (leave it for you). First is for simple character vector input and second is for list of character vectors. Second is slightly faster (~30%) than with first one + `lapply` (mainly because of single initialisation of stopwords set). 
Also new generators allows to generate multiple n-gram sequences (say simultaneously 2-grams and 3-grams). Both functions are about 1.5 - 2x faster than `shingle_ngrams`.

``` r
library(magrittr)
library(text2vec)
library(tokenizers)
library(microbenchmark)
data("movie_review")
tokens <- movie_review$review %>% tolower %>% word_tokenizer
stopwords <- character(0)
N <- 3
times = 5
microbenchmark(
  base <-lapply(tokens, tokenizers:::shingle_ngrams, n = N), 
  new_lapply <-lapply(tokens, tokenizers:::generate_ngrams, ngram_min = N, ngram_max = N, stopwords = stopwords, ngram_delim = ' '),
  new_batch <- tokenizers:::generate_ngrams_batch(tokens, ngram_min = N, ngram_max = N, stopwords = stopwords, ngram_delim = ' ' ), 
  times = times)

# lq mean median uq max neval
#745.1356 841.9614 821.8592 923.2065 989.9606     5
#512.4596 531.1537 512.6780 545.4777 575.6497     5
#448.9108 457.0947 454.1571 463.6830 478.5642     5

identical(base, new_lapply)
# TRUE
identical(new_batch, new_lapply)
# TRUE
```

And here is example of usage with `stopwords` argument:

``` r
words <- sort(table(unlist(tokens, use.names = F)), decreasing = T)
stopwords <- head(names(words), 20)


N <- 3
microbenchmark(
  new_batch <- tokenizers:::generate_ngrams_batch(tokens, ngram_min = N, ngram_max = N, stopwords = stopwords, ngram_delim = ' ' ), 
  times = times
)
# min lq mean median uq max neval
#367.5149 369.7329 384.2632 369.9419 373.1821 440.9441     5
```

And as you can see with stopwords filtering it works even faster!
