### PR TITLE
Fix #33

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 - Add a function `chunk_text()` to split long documents into pieces.
 - Add the `tokenize_ptb()` function for Penn Tree Bank tokenizations (@jrnold).
 - C++98 has replaced the C++11 code used for ngram generation, widening the range of compilers `tokenizers` supports (#26)
+- If tokenisers fail to generate tokens for a particular entry, they return NA consistently (#33)
 
 # tokenizers 0.1.4
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -17,5 +17,9 @@ check_input <- function(x) {
 }
 
 remove_stopwords <- function(x, stopwords) {
-  x[!x %in% stopwords]
+  out <- x[!x %in% stopwords]
+  if(!length(out)){
+    return(NA_character_)
+  }
+  return(out)
 }

--- a/src/shingle_ngrams.cpp
+++ b/src/shingle_ngrams.cpp
@@ -32,6 +32,7 @@ CharacterVector generate_ngrams_internal(const CharacterVector terms_raw,
   }
 
   int len = terms_filtered_buffer.size();
+  int result_len;
   size_t ngram_out_len = get_ngram_seq_len(len, ngram_min, std::min(ngram_max, len));
 
   CharacterVector result(ngram_out_len);
@@ -60,6 +61,10 @@ CharacterVector generate_ngrams_internal(const CharacterVector terms_raw,
       j_max_observed = j + k;
       k = k + 1;
     }
+  }
+
+  if(!result.size()){
+    result.push_back(NA_STRING);
   }
   return result;
 }

--- a/src/skip_ngrams.cpp
+++ b/src/skip_ngrams.cpp
@@ -13,6 +13,9 @@ CharacterVector skip_ngrams(CharacterVector words, int n, int k) {
     if(window > w) continue;
     g += w - window + 1;
   }
+  if(!g){
+    return CharacterVector(1, NA_STRING);
+  }
   CharacterVector ngrams(g);
 
   int position = 0; // position = place to store current ngram

--- a/tests/testthat/test-ngrams.R
+++ b/tests/testthat/test-ngrams.R
@@ -38,6 +38,13 @@ test_that("Shingled n-gram tokenizer produces correct output", {
 
 })
 
+test_that("Shingled n-gram tokenizer consistently produces NAs where appropriate", {
+  test <- c("This is a text", NA, "So is this")
+  names(test) <- letters[1:3]
+  out <- tokenize_ngrams(test)
+  expect_true(is.na(out$b))
+})
+
 test_that("Skip n-gram tokenizer works as expected", {
   stopwords <- c("chapter", "me")
   out_l <- tokenize_skip_ngrams(docs_l, n = 3, k = 2)
@@ -67,4 +74,11 @@ test_that("Skip n-gram tokenizer produces correct output", {
   expected <- c("chapter call some", "1 me years", "loomings ishmael ago",
                 "call some never", "me years mind", "ishmael ago how")
   expect_identical(head(out_1, 6), expected)
+})
+
+test_that("Skip n-gram tokenizer consistently produces NAs where appropriate", {
+  test <- c("This is a text", NA, "So is this")
+  names(test) <- letters[1:3]
+  out <- tokenize_skip_ngrams(test)
+  expect_true(is.na(out$b))
 })

--- a/tests/testthat/test-shingles.R
+++ b/tests/testthat/test-shingles.R
@@ -40,3 +40,10 @@ test_that("Character shingle tokenizer produces correct output", {
                                           " to", "to ", "o s", " se", "see"))
 
 })
+
+test_that("Character shingle tokenizer consistently produces NAs where appropriate", {
+  test <- c("This is a text", NA, "So is this")
+  names(test) <- letters[1:3]
+  out <- tokenize_character_shingles(test)
+  expect_true(is.na(out$b))
+})


### PR DESCRIPTION
```
library(tokenizers)
test <- c("This is a text", NA, "So is this")
names(test) <- letters[1:3]
stops <- c("a", NA)
# Input with NA
tokenize_words(test)
#> $a
#> [1] "this" "is"   "a"    "text"
#> 
#> $b
#> [1] NA
#> 
#> $c
#> [1] "so"   "is"   "this"
# Input with NA
tokenize_ngrams(test, n = 2)
#> $a
#> [1] "this is" "is a"    "a text" 
#> 
#> $b
#> [1] NA
#> 
#> $c
#> [1] "so is"   "is this"
# Input with NA, stopwords with NA
tokenize_words(test, stopwords = stops)
#> $a
#> [1] "this" "is"   "text"
#> 
#> $b
#> [1] NA
#> 
#> $c
#> [1] "so"   "is"   "this"
# Input with NA, stopwords with NA
tokenize_ngrams(test, n = 2, stopwords = stops)
#> $a
#> [1] "this is" "is text"
#> 
#> $b
#> [1] NA
#> 
#> $c
#> [1] "so is"   "is this"
# Skip ngrams
tokenizers::tokenize_skip_ngrams(test)
# $a
# [1] "this is a" "is a text"
# 
# $b
# [1] NA
# 
# $c
# [1] "so is this"
```