### PR TITLE
Fix #31

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 - Add the `tokenize_ptb()` function for Penn Tree Bank tokenizations (@jrnold).
 - C++98 has replaced the C++11 code used for ngram generation, widening the range of compilers `tokenizers` supports (#26)
 - If tokenisers fail to generate tokens for a particular entry, they return NA consistently (#33)
+- `tokenize_skip_ngrams` now supports stopwords (#31)
 
 # tokenizers 0.1.4
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -5,7 +5,7 @@ generate_ngrams_batch <- function(documents_list, ngram_min, ngram_max, stopword
     .Call('tokenizers_generate_ngrams_batch', PACKAGE = 'tokenizers', documents_list, ngram_min, ngram_max, stopwords, ngram_delim)
 }
 
-skip_ngrams <- function(words, n, k) {
-    .Call('tokenizers_skip_ngrams', PACKAGE = 'tokenizers', words, n, k)
+skip_ngrams_vectorised <- function(words, stopwords, n, k) {
+    .Call('tokenizers_skip_ngrams_vectorised', PACKAGE = 'tokenizers', words, stopwords, n, k)
 }
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -5,7 +5,7 @@ generate_ngrams_batch <- function(documents_list, ngram_min, ngram_max, stopword
     .Call('tokenizers_generate_ngrams_batch', PACKAGE = 'tokenizers', documents_list, ngram_min, ngram_max, stopwords, ngram_delim)
 }
 
-skip_ngrams_vectorised <- function(words, stopwords, n, k) {
-    .Call('tokenizers_skip_ngrams_vectorised', PACKAGE = 'tokenizers', words, stopwords, n, k)
+skip_ngrams_vectorised <- function(words, skips, stopwords) {
+    .Call('tokenizers_skip_ngrams_vectorised', PACKAGE = 'tokenizers', words, skips, stopwords)
 }
 

--- a/R/ngram-tokenizers.R
+++ b/R/ngram-tokenizers.R
@@ -78,11 +78,11 @@ tokenize_ngrams <- function(x, lowercase = TRUE, n = 3L, n_min = n,
 #' @export
 #' @rdname ngram-tokenizers
 tokenize_skip_ngrams <- function(x, lowercase = TRUE, n = 3, k = 1,
-                                 simplify = FALSE) {
+                                 stopwords = character(), simplify = FALSE) {
   check_input(x)
   named <- names(x)
   words <- tokenize_words(x, lowercase = lowercase)
-  out <- lapply(words, skip_ngrams, n = n, k = k)
+  out <- skip_ngrams_vectorised(words, stopwords, n, k)
   if (!is.null(named)) names(out) <- named
   simplify_list(out, simplify)
 }

--- a/R/ngram-tokenizers.R
+++ b/R/ngram-tokenizers.R
@@ -103,12 +103,13 @@ get_valid_skips <- function(n, k) {
 
 #' @export
 #' @rdname ngram-tokenizers
-tokenize_skip_ngrams <- function(x, lowercase = TRUE, n = 3, k = 1,
+tokenize_skip_ngrams <- function(x, lowercase = TRUE, n_min = 1, n = 3, k = 1,
                                  stopwords = character(), simplify = FALSE) {
   check_input(x)
   named <- names(x)
   words <- tokenize_words(x, lowercase = lowercase)
-  skips <- get_valid_skips(n, k)
+  skips <- unique(unlist(lapply(n_min:n, get_valid_skips, k),
+                         recursive = FALSE, use.names = FALSE))
   out <- skip_ngrams_vectorised(words, skips, stopwords)
   if (!is.null(named)) names(out) <- named
   simplify_list(out, simplify)

--- a/man/ngram-tokenizers.Rd
+++ b/man/ngram-tokenizers.Rd
@@ -9,7 +9,7 @@
 tokenize_ngrams(x, lowercase = TRUE, n = 3L, n_min = n,
   stopwords = character(), ngram_delim = " ", simplify = FALSE)
 
-tokenize_skip_ngrams(x, lowercase = TRUE, n = 3, k = 1,
+tokenize_skip_ngrams(x, lowercase = TRUE, n_min = 1, n = 3, k = 1,
   stopwords = character(), simplify = FALSE)
 }
 \arguments{

--- a/man/ngram-tokenizers.Rd
+++ b/man/ngram-tokenizers.Rd
@@ -10,7 +10,7 @@ tokenize_ngrams(x, lowercase = TRUE, n = 3L, n_min = n,
   stopwords = character(), ngram_delim = " ", simplify = FALSE)
 
 tokenize_skip_ngrams(x, lowercase = TRUE, n = 3, k = 1,
-  simplify = FALSE)
+  stopwords = character(), simplify = FALSE)
 }
 \arguments{
 \item{x}{A character vector or a list of character vectors to be tokenized

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -20,16 +20,17 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// skip_ngrams
-CharacterVector skip_ngrams(CharacterVector words, int n, int k);
-RcppExport SEXP tokenizers_skip_ngrams(SEXP wordsSEXP, SEXP nSEXP, SEXP kSEXP) {
+// skip_ngrams_vectorised
+ListOf<CharacterVector> skip_ngrams_vectorised(ListOf<CharacterVector> words, CharacterVector stopwords, int n, int k);
+RcppExport SEXP tokenizers_skip_ngrams_vectorised(SEXP wordsSEXP, SEXP stopwordsSEXP, SEXP nSEXP, SEXP kSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< CharacterVector >::type words(wordsSEXP);
+    Rcpp::traits::input_parameter< ListOf<CharacterVector> >::type words(wordsSEXP);
+    Rcpp::traits::input_parameter< CharacterVector >::type stopwords(stopwordsSEXP);
     Rcpp::traits::input_parameter< int >::type n(nSEXP);
     Rcpp::traits::input_parameter< int >::type k(kSEXP);
-    rcpp_result_gen = Rcpp::wrap(skip_ngrams(words, n, k));
+    rcpp_result_gen = Rcpp::wrap(skip_ngrams_vectorised(words, stopwords, n, k));
     return rcpp_result_gen;
 END_RCPP
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -21,16 +21,15 @@ BEGIN_RCPP
 END_RCPP
 }
 // skip_ngrams_vectorised
-ListOf<CharacterVector> skip_ngrams_vectorised(ListOf<CharacterVector> words, CharacterVector stopwords, int n, int k);
-RcppExport SEXP tokenizers_skip_ngrams_vectorised(SEXP wordsSEXP, SEXP stopwordsSEXP, SEXP nSEXP, SEXP kSEXP) {
+ListOf<CharacterVector> skip_ngrams_vectorised(ListOf<CharacterVector> words, ListOf<NumericVector> skips, CharacterVector stopwords);
+RcppExport SEXP tokenizers_skip_ngrams_vectorised(SEXP wordsSEXP, SEXP skipsSEXP, SEXP stopwordsSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< ListOf<CharacterVector> >::type words(wordsSEXP);
+    Rcpp::traits::input_parameter< ListOf<NumericVector> >::type skips(skipsSEXP);
     Rcpp::traits::input_parameter< CharacterVector >::type stopwords(stopwordsSEXP);
-    Rcpp::traits::input_parameter< int >::type n(nSEXP);
-    Rcpp::traits::input_parameter< int >::type k(kSEXP);
-    rcpp_result_gen = Rcpp::wrap(skip_ngrams_vectorised(words, stopwords, n, k));
+    rcpp_result_gen = Rcpp::wrap(skip_ngrams_vectorised(words, skips, stopwords));
     return rcpp_result_gen;
 END_RCPP
 }

--- a/src/init.c
+++ b/src/init.c
@@ -5,11 +5,11 @@
 
 /* .Call calls */
 extern SEXP tokenizers_generate_ngrams_batch(SEXP, SEXP, SEXP, SEXP, SEXP);
-extern SEXP tokenizers_skip_ngrams(SEXP, SEXP, SEXP);
+extern SEXP tokenizers_skip_ngrams_vectorised(SEXP, SEXP, SEXP, SEXP);
 
 static const R_CallMethodDef CallEntries[] = {
-    {"tokenizers_generate_ngrams_batch", (DL_FUNC) &tokenizers_generate_ngrams_batch, 5},
-    {"tokenizers_skip_ngrams",           (DL_FUNC) &tokenizers_skip_ngrams,           3},
+    {"tokenizers_generate_ngrams_batch",  (DL_FUNC) &tokenizers_generate_ngrams_batch, 5},
+    {"tokenizers_skip_ngrams_vectorised", (DL_FUNC) &tokenizers_skip_ngrams_vectorised,4},
     {NULL, NULL, 0}
 };
 

--- a/src/init.c
+++ b/src/init.c
@@ -5,11 +5,11 @@
 
 /* .Call calls */
 extern SEXP tokenizers_generate_ngrams_batch(SEXP, SEXP, SEXP, SEXP, SEXP);
-extern SEXP tokenizers_skip_ngrams_vectorised(SEXP, SEXP, SEXP, SEXP);
+extern SEXP tokenizers_skip_ngrams_vectorised(SEXP, SEXP, SEXP);
 
 static const R_CallMethodDef CallEntries[] = {
     {"tokenizers_generate_ngrams_batch",  (DL_FUNC) &tokenizers_generate_ngrams_batch, 5},
-    {"tokenizers_skip_ngrams_vectorised", (DL_FUNC) &tokenizers_skip_ngrams_vectorised,4},
+    {"tokenizers_skip_ngrams_vectorised", (DL_FUNC) &tokenizers_skip_ngrams_vectorised,3},
     {NULL, NULL, 0}
 };
 

--- a/src/shingle_ngrams.cpp
+++ b/src/shingle_ngrams.cpp
@@ -32,7 +32,6 @@ CharacterVector generate_ngrams_internal(const CharacterVector terms_raw,
   }
 
   int len = terms_filtered_buffer.size();
-  int result_len;
   size_t ngram_out_len = get_ngram_seq_len(len, ngram_min, std::min(ngram_max, len));
 
   CharacterVector result(ngram_out_len);

--- a/src/skip_ngrams.cpp
+++ b/src/skip_ngrams.cpp
@@ -6,29 +6,45 @@ CharacterVector skip_ngrams(CharacterVector words,
                             std::set<std::string>& stopwords) {
 
   std::deque < std::string > checked_words;
-  std::string holding;
+  std::string str_holding;
 
+  // Eliminate stopwords
   for(unsigned int i = 0; i < words.size(); i++){
     if(words[i] != NA_STRING){
-      holding = as<std::string>(words[i]);
-      if(stopwords.find(holding)  == stopwords.end()){
-        checked_words.push_back(holding);
+      str_holding = as<std::string>(words[i]);
+      if(stopwords.find(str_holding)  == stopwords.end()){
+        checked_words.push_back(str_holding);
       }
     }
   }
 
-  CharacterVector output(skips.size());
+  str_holding.clear();
+  std::deque < std::string > holding;
+  unsigned int checked_size = checked_words.size();
 
   for(unsigned int i = 0; i < skips.size(); i++){
-    std::string holding;
-    for(unsigned int j = 0; j < skips[i].size(); j++){
-      if(skips[i][j] < (checked_words.size() - 1)){
-        holding += " " + checked_words[skips[i][j]];
+    unsigned int in_size = skips[i].size();
+    if(skips[i][in_size-1] < checked_size){
+      for(unsigned int j = 0; j < skips[i].size(); j++){
+        str_holding += " " + checked_words[skips[i][j]];
       }
+      if(str_holding.size()){
+        str_holding.erase(0,1);
+      }
+      holding.push_back(str_holding);
+      str_holding.clear();
     }
-    if(holding.size()){
-      holding.erase(0,1);
-      output[i] = holding;
+  }
+
+  if(!holding.size()){
+    return CharacterVector(1,NA_STRING);
+  }
+
+  CharacterVector output(holding.size());
+
+  for(unsigned int i = 0; i < holding.size(); i++){
+    if(holding[i].size()){
+      output[i] = holding[i];
     } else {
       output[i] = NA_STRING;
     }

--- a/tests/testthat/test-ngrams.R
+++ b/tests/testthat/test-ngrams.R
@@ -82,3 +82,12 @@ test_that("Skip n-gram tokenizer consistently produces NAs where appropriate", {
   out <- tokenize_skip_ngrams(test)
   expect_true(is.na(out$b))
 })
+
+
+test_that("Skip n-gram tokenizer can use stopwords", {
+  test <- c("This is a text", "So is this")
+  names(test) <- letters[1:2]
+  out <- tokenize_skip_ngrams(test, stopwords = "is", n = 2)
+  expect_equal(length(out$a), 3)
+  expect_identical(out$a[2], "this a")
+})

--- a/tests/testthat/test-ngrams.R
+++ b/tests/testthat/test-ngrams.R
@@ -71,8 +71,8 @@ test_that("Skip n-gram tokenizer works as expected", {
 test_that("Skip n-gram tokenizer produces correct output", {
   # skip_on_os("windows")
   out_1 <- tokenize_skip_ngrams(docs_c[1], n = 3, k = 2, simplify = TRUE)
-  expected <- c("chapter call some", "1 me years", "loomings ishmael ago",
-                "call some never", "me years mind", "ishmael ago how")
+  expected <- c("chapter", "chapter 1", "chapter loomings",
+                "chapter call", "chapter 1 loomings", "chapter 1 call")
   expect_identical(head(out_1, 6), expected)
 })
 


### PR DESCRIPTION
This fixes #31 . It's a bit more complicated than one might think from the description, essentially because the most efficient way to check stopwords is with a set object, which needs to be constructed within C++. Accordingly I've shifted the vectorisation to compiled code, so that the set object only needs to be constructed once.