### PR TITLE
Use official docs URL in description

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,7 @@ Authors@R: c(person("Lincoln", "Mullen", role = c("aut", "cre"),
         person("Kenneth", "Benoit", role = c("ctb"),
         email = "kbenoit@lse.ac.uk",
         comment = c(ORCID = "0000-0002-0797-564X")))
-URL: https://lincolnmullen.com/software/tokenizers/, https://github.com/ropensci/tokenizers
+URL: https://docs.ropensci.org/tokenizers/, https://github.com/ropensci/tokenizers
 BugReports: https://github.com/ropensci/tokenizers/issues
 RoxygenNote: 6.0.1
 Depends:


### PR DESCRIPTION
We are now automatically building pkgdown docs for all packages. If you'd like you can use this as the official homepage of the package. But if you prefer a copy on your own domain, that's fine too.