### PR TITLE
Split into words in tokenize_tweets even when strip_punct is set to TRUE

### DIFF
--- a/R/tokenize_tweets.R
+++ b/R/tokenize_tweets.R
@@ -64,14 +64,31 @@ tokenize_tweets.default <- function(x,
   if (!is.null(stopwords))
     out <- sapply(out, remove_stopwords, stopwords, USE.NAMES = FALSE)
 
-  # split all except URLs, twitter hashtags, and usernames into words.
-  out[!index_url & !index_twitter] <-
-    stri_split_boundaries(out[!index_url & !index_twitter], type = "word")
-
   if (strip_punct) {
+    # split all except URLs, twitter hashtags, and usernames into words.
+    out[!index_url & !index_twitter] <-
+      stri_split_boundaries(out[!index_url & !index_twitter], type = "word")
     out[!index_url & !index_twitter] <-
       lapply(out[!index_url & !index_twitter], function(toks) {
         stri_replace_all_charclass(toks, "\\p{P}", "")
+      })
+
+    # preserve twitter characters, strip all punctuations,
+    # then put back the twitter characters.
+    twitter_chars <- stri_sub(out[index_twitter], 1, 1)
+    out[index_twitter] <-
+      stri_replace_all_charclass(out[index_twitter], "\\p{P}", "")
+    out[index_twitter] <- paste0(twitter_chars, out[index_twitter])
+  }
+  else {
+    # split all except URLs.
+    out[!index_url] <-
+      stri_split_boundaries(out[!index_url], type = "word")
+    # rejoin the hashtags and usernames
+    out[index_twitter] <-
+      lapply(out[index_twitter], function(toks) {
+        toks[2] <- paste0(toks[1], toks[2])
+        toks[-1]
       })
   }
 

--- a/R/tokenize_tweets.R
+++ b/R/tokenize_tweets.R
@@ -64,20 +64,14 @@ tokenize_tweets.default <- function(x,
   if (!is.null(stopwords))
     out <- sapply(out, remove_stopwords, stopwords, USE.NAMES = FALSE)
 
+  # split all except URLs, twitter hashtags, and usernames into words.
+  out[!index_url & !index_twitter] <-
+    stri_split_boundaries(out[!index_url & !index_twitter], type = "word")
+
   if (strip_punct) {
-    twitter_chars <- stri_sub(out[index_twitter], 1, 1)
-    out[!index_url] <-
-      stri_replace_all_charclass(out[!index_url], "\\p{P}", "")
-    out[index_twitter] <- paste0(twitter_chars, out[index_twitter])
-  } else {
-    # all except URLs
-    out[!index_url] <-
-      stri_split_boundaries(out[!index_url], type = "word")
-    # rejoin the hashtags and usernames
-    out[index_twitter] <-
-      lapply(out[index_twitter], function(toks) {
-        toks[2] <- paste0(toks[1], toks[2])
-        toks[-1]
+    out[!index_url & !index_twitter] <-
+      lapply(out[!index_url & !index_twitter], function(toks) {
+        stri_replace_all_charclass(toks, "\\p{P}", "")
       })
   }
 

--- a/tests/testthat/test-tokenize_tweets.R
+++ b/tests/testthat/test-tokenize_tweets.R
@@ -94,3 +94,10 @@ test_that("stopwords removal works the same as with tokenize_words", {
     tokenize_tweets(txt, stopwords = c("i'm"), strip_punct = FALSE)
   )
 })
+
+test_that("tokenizing non-space-separated language works", {
+  expect_equal(
+    tokenize_tweets("\u4ECA\u65E5\u3082\u3088\u3044\u5929\u6C17\u3002", simplify = TRUE),
+    c("\u4ECA\u65E5", "\u3082", "\u3088\u3044", "\u5929\u6C17")
+  )
+})


### PR DESCRIPTION
tokenize_tweets did not split the input into words if strip_punct is set to TRUE.
This PR made the change to split into words even in this case.

Non-space-separated languages like Japanese were not tokenized into words because of this issue.
I added a test case for it.

It also fixes #68.